### PR TITLE
Fix HttpError references for new BifrostPHP version

### DIFF
--- a/api/Attributes/Auth.php
+++ b/api/Attributes/Auth.php
@@ -4,7 +4,7 @@ namespace Bifrost\Attributes;
 
 use Bifrost\Class\Auth as ClassAuth;
 use Bifrost\Interface\AttributesInterface;
-use Bifrost\Class\HttpError;
+use Bifrost\Class\HttpResponse;
 use Bifrost\DataTypes\Email;
 
 #[\Attribute]
@@ -26,16 +26,16 @@ class Auth implements AttributesInterface
             $password = $_SERVER['PHP_AUTH_PW'];
 
             if (!ClassAuth::autenticate($email, $password)) {
-                return HttpError::unauthorized("Credenciais inválidas");
+                return HttpResponse::unauthorized("Credenciais inválidas");
             }
         }
 
         if (!ClassAuth::isLogged()) {
-            return HttpError::unauthorized("Usuário não autenticado");
+            return HttpResponse::unauthorized("Usuário não autenticado");
         }
 
         if (!ClassAuth::hasRole(self::$roles)) {
-            return HttpError::forbidden("Usuário não autorizado");
+            return HttpResponse::forbidden("Usuário não autorizado");
         }
 
         ClassAuth::setIdentifierOnDatabase();

--- a/api/Class/Role.php
+++ b/api/Class/Role.php
@@ -4,6 +4,8 @@ namespace Bifrost\Class;
 
 use Bifrost\DataTypes\UUID;
 use Bifrost\Model\Role as RoleModel;
+use Bifrost\Class\HttpResponse;
+use Bifrost\Core\AppError;
 
 class Role
 {
@@ -26,10 +28,15 @@ class Role
         }
 
         if (empty($roleData)) {
-            throw HttpError::internalServerError("Role not found", [
-                "id" => $id,
-                "code" => $code,
-            ]);
+            throw new AppError(
+                HttpResponse::internalServerError(
+                    errors: [
+                        "id" => $id,
+                        "code" => $code,
+                    ],
+                    message: "Role not found"
+                )
+            );
         }
 
         $this->id = new UUID($roleData["id"]);

--- a/api/Controller/auth.php
+++ b/api/Controller/auth.php
@@ -7,7 +7,6 @@ use Bifrost\Attributes\Method;
 use Bifrost\Attributes\RequiredFields;
 use Bifrost\Attributes\Auth as AuthAttribute;
 use Bifrost\Class\Auth as ClassAuth;
-use Bifrost\Class\HttpError;
 use Bifrost\Class\HttpResponse;
 use Bifrost\Enum\Field;
 use Bifrost\Interface\ControllerInterface;
@@ -38,7 +37,7 @@ class Auth implements ControllerInterface
 
         return ClassAuth::autenticate($email, $password) ?
             HttpResponse::success("Usuário logado com sucesso") :
-            HttpError::unauthorized("Usuário ou senha invalidos");
+            HttpResponse::unauthorized("Usuário ou senha invalidos");
     }
 
     #[Method("GET")]

--- a/api/Controller/folder.php
+++ b/api/Controller/folder.php
@@ -11,7 +11,6 @@ use Bifrost\Attributes\OptionalFields;
 use Bifrost\Attributes\OptionalParams;
 use Bifrost\Class\Auth as ClassAuth;
 use Bifrost\Class\HttpResponse;
-use Bifrost\Class\HttpError;
 use Bifrost\Class\Folder as FolderClass;
 use Bifrost\Core\Post;
 use Bifrost\Core\Request;
@@ -40,7 +39,7 @@ class Folder implements ControllerInterface
                     "new" => Request::getOptionsAttributes($controller, "new")
                 ]);
             default:
-                return HttpError::methodNotAllowed("Method not allowed");
+                return HttpResponse::methodNotAllowed("Method not allowed");
         }
     }
 
@@ -66,17 +65,20 @@ class Folder implements ControllerInterface
         if ($post->parent_id) {
             $id = new UUID($post->parent_id);
             if (!FolderClass::validId($id)) {
-                return HttpError::badRequest("Parent ID is not valid", [
-                    "fieldName" => "parent_id",
-                    "fieldValue" => (string) $post->parent_id
-                ]);
+                return HttpResponse::badRequest(
+                    errors: [
+                        "fieldName" => "parent_id",
+                        "fieldValue" => (string) $post->parent_id
+                    ],
+                    message: "Parent ID is not valid"
+                );
             }
 
             $parent = new FolderClass(id: $id);
         }
 
         if (FolderClass::exists(name: $name, reference: $parent ?? $user)) {
-            return HttpError::badRequest("Folder already exists");
+            return HttpResponse::badRequest([], "Folder already exists");
         }
 
         $folder = FolderClass::new(

--- a/api/Controller/user.php
+++ b/api/Controller/user.php
@@ -9,7 +9,6 @@ use Bifrost\Attributes\Details;
 use Bifrost\Attributes\Method;
 use Bifrost\Attributes\RequiredFields;
 use Bifrost\Attributes\RequiredParams;
-use Bifrost\Class\HttpError;
 use Bifrost\Class\HttpResponse;
 use Bifrost\Core\Request;
 use Bifrost\Class\User as UserClass;
@@ -53,7 +52,7 @@ class User implements ControllerInterface
                     "update" => Request::getOptionsAttributes($controller, "update"),
                 ]);
             default:
-                return HttpError::methodNotAllowed("Method not allowed");
+                return HttpResponse::methodNotAllowed("Method not allowed");
         }
     }
 
@@ -80,7 +79,7 @@ class User implements ControllerInterface
         ],
         "description" => "Cria um novo usuário no sistema"
     ])]
-    public function new(): HttpError|HttpResponse
+    public function new(): HttpResponse
     {
         $post = new Post();
 
@@ -90,7 +89,7 @@ class User implements ControllerInterface
         $password = $post->password;
 
         if (UserClass::exists(email: $email, userName: $userName)) {
-            return HttpError::badRequest("User already exists");
+            return HttpResponse::badRequest([], "User already exists");
         }
 
         $roleClass = new RoleClass();
@@ -119,12 +118,12 @@ class User implements ControllerInterface
     #[Details([
         "description" => "Lista um usuário do sistema"
     ])]
-    public function get(): HttpError|HttpResponse
+    public function get(): HttpResponse
     {
         $get = new Get();
 
         if (!UserModel::exists(["id" => $get->id])) {
-            return HttpError::notFound("User not found");
+            return HttpResponse::notFound([], "User not found");
         }
 
         $id = new UUID($get->id);
@@ -157,7 +156,7 @@ class User implements ControllerInterface
         $get = new Get();
 
         if (!UserModel::exists(["id" => $get->id])) {
-            return HttpError::notFound("User not found");
+            return HttpResponse::notFound([], "User not found");
         }
 
         $id = new UUID($get->id);
@@ -198,12 +197,12 @@ class User implements ControllerInterface
     #[Details([
         "description" => "Deleta um usuário e todos os seus dados relacionados"
     ])]
-    public function delete(): HttpError|HttpResponse
+    public function delete(): HttpResponse
     {
         $get = new Get();
 
         if (!UserModel::exists(["id" => $get->id])) {
-            return HttpError::notFound("User not found");
+            return HttpResponse::notFound([], "User not found");
         }
 
         $id = new UUID($get->id);
@@ -216,6 +215,6 @@ class User implements ControllerInterface
             );
         }
 
-        return HttpError::internalServerError("Error deleting user");
+        return HttpResponse::internalServerError([], "Error deleting user");
     }
 }

--- a/api/Core/Settings.php
+++ b/api/Core/Settings.php
@@ -55,7 +55,7 @@ final class Settings
      *
      * @param string $param The name of the property to be returned.
      * @param bool $required Indicates whether the property is required.
-     * @uses HttpError::__construct()
+     * @uses AppError::__construct()
      * @return mixed
      */
     protected static function getEnv(string $param, bool $required = false): mixed


### PR DESCRIPTION
## Summary
- update Auth attribute to use HttpResponse
- update auth, folder and user controllers for HttpResponse/AppError
- convert Role class to throw AppError with HttpResponse
- update Settings docs for AppError

## Testing
- `apt-get update`
- `apt-get install -y php-cli`
- `find api -name '*.php' | xargs -I{} php -l {}`

------
https://chatgpt.com/codex/tasks/task_e_68449fb256d4832fa4b37c0eb440f3e3